### PR TITLE
Specify return type for num operator ==

### DIFF
--- a/hash.cpp
+++ b/hash.cpp
@@ -154,7 +154,7 @@ void k2hash::RunUnitTests()
         num(int nmb){n = nmb;}
         num(int nmb, char chr) {n = nmb; c = chr;}
         unsigned char hash() const {return static_cast<unsigned char>(n % 10);}
-        operator ==(const num x) {return n == x.n;}
+        bool operator ==(const num x) {return n == x.n;}
     };
 
     transposition_table_c<num, unsigned char, 4> tt(16);


### PR DESCRIPTION
    hash.cpp: In member function 'void k2hash::RunUnitTests()':
    hash.cpp:157:9: error: ISO C++ forbids declaration of 'operator==' with no type [-fpermissive]
      157 |         operator ==(const num x) {return n == x.n;}
          |         ^~~~~~~~
    make: *** [Makefile:370: hash.o] Error 1